### PR TITLE
Show eth0 addresses on startup

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -47,7 +47,10 @@ echo "The warrior has successfully started up."
 echo
 echo "To manage your warrior, open your web browser"
 echo "and login to the web interface at"
-echo " http://127.0.0.1:8001"
+echo "  http://127.0.0.1:8001"
+echo
+echo "These IPs are bound to eth0:"
+ip addr show dev eth0 | awk '{if (match($1, "inet6?") != 0) print "> "$2}'
 echo
 sleep 20
 


### PR DESCRIPTION
I love to use the bridged mode and the hardcoded localhost address that's shown isn't pretty.

Output:
```
These IPs are bound to eth0:
> 123.123.123.15/24
> fe80::a00:27ff:fe7f:aaca/64
```

What we also could do, refer people to our \#warrior IRC in case they have problems (and aren't aware of means to contact us).