### PR TITLE
Migrate to new Warrior image, other enhancements

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -89,8 +89,11 @@ if docker exec -it warrior test -f /tmp/warrior_reboot_required; then
     echo "Detected warrior needing reboot. Rebooting!"
     reboot
 elif docker exec -it warrior test -f /tmp/warrior_poweroff_required; then
-    echo "Detected warrior needing poweroff. Powering off!"
-    poweroff
+    sleep 5 # Prevent a Watchtower update from shutting down the system
+    if docker exec -it warrior test -f /tmp/warrior_poweroff_required; then
+        echo "Detected warrior needing poweroff. Powering off!"
+        poweroff
+    fi
 elif docker ps -f name=warrior -f status=dead | grep warrior; then
     echo "Docker container instance dead. Rebooting!"
     reboot

--- a/startup.sh
+++ b/startup.sh
@@ -29,7 +29,7 @@ if [ ! "$(docker ps -a --format {{.Names}} | grep warrior)" ]; then
     echo "This may take a few minutes..."
     # Mount the user configuration from the host container
     # https://stackoverflow.com/a/54787364, https://docs.docker.com/storage/bind-mounts
-    docker run -d -p 8001:8001 --name warrior -v/root/config.json:/home/warrior/projects/config.json:z atdr.meo.ws/archiveteam/warrior-dockerfile
+    docker run -d -p 8001:8001 --name warrior -v /root/config.json:/home/warrior/projects/config.json:z atdr.meo.ws/archiveteam/warrior-dockerfile
     # Allow reading network stats by non-root
     docker exec -it warrior adduser warrior dip
 else

--- a/startup.sh
+++ b/startup.sh
@@ -27,7 +27,9 @@ fi
 if [ ! "$(docker ps -a --format {{.Names}} | grep warrior)" ]; then
     echo "Please wait while the Warrior is downloaded and started..."
     echo "This may take a few minutes..."
-    docker run -d -p 8001:8001 --name warrior --mount type=bind,source=/root/config.json,target=/home/warrior/projects/config.json atdr.meo.ws/archiveteam/warrior-dockerfile
+    # Mount the user configuration from the host container
+    # https://stackoverflow.com/a/54787364, https://docs.docker.com/storage/bind-mounts
+    docker run -d -p 8001:8001 --name warrior -v/root/config.json:/home/warrior/projects/config.json:z atdr.meo.ws/archiveteam/warrior-dockerfile
     # Allow reading network stats by non-root
     docker exec -it warrior adduser warrior dip
 else

--- a/startup.sh
+++ b/startup.sh
@@ -49,8 +49,8 @@ if [ ! "$(docker ps -a --format {{.Names}} | grep warrior)" ]; then
     # Mount the user configuration from the host container
     # https://stackoverflow.com/a/54787364, https://docs.docker.com/storage/bind-mounts
     docker run -d -p 8001:8001 --name warrior -v /root/config.json:/home/warrior/projects/config.json atdr.meo.ws/archiveteam/warrior-dockerfile
-    # Allow reading network stats by non-root
-    docker exec -it warrior adduser warrior dip
+    # Allow reading network stats by non-root (unneeded and outputs a permissions error)
+    # docker exec -it warrior adduser warrior dip
 else
     docker start warrior
 fi

--- a/startup.sh
+++ b/startup.sh
@@ -49,8 +49,8 @@ if [ ! "$(docker ps -a --format {{.Names}} | grep warrior)" ]; then
     # Mount the user configuration from the host container
     # https://stackoverflow.com/a/54787364, https://docs.docker.com/storage/bind-mounts
     docker run -d -p 8001:8001 --name warrior -v /root/config.json:/home/warrior/projects/config.json atdr.meo.ws/archiveteam/warrior-dockerfile
-    # Allow reading network stats by non-root (unneeded and outputs a permissions error)
-    # docker exec -it warrior adduser warrior dip
+    # Allow reading network stats by non-root
+    docker exec -it warrior adduser warrior dip
 else
     docker start warrior
 fi

--- a/startup.sh
+++ b/startup.sh
@@ -1,6 +1,14 @@
 #!/bin/sh
 reset
 echo "=== Starting Warrior Download ==="
+
+# Versions 3.0 and 3.1 of the VM image use a file at /root/docker_container_id.txt to keep track
+# of the container ID for the Warrior image. If this file is detected, the user is migrated to
+# the new Warrior container. The migration process consists of extracting the user configuration
+# file from the old container and then deleting the old container, pruning Docker containers,
+# networks, and images (the --volumes parameter is not supported on the Docker version in the
+# 3.0 VM image), and deleting the /root/docker_container_id.txt file.
+# https://docs.docker.com/engine/reference/commandline/system_prune/
 if [ -f /root/docker_container_id.txt ]; then
     echo "A new, upgraded Warrior capable of running more projects is available and will now be installed..."
     CONTAINER_ID=`cat /root/docker_container_id.txt`
@@ -19,6 +27,8 @@ touch /root/config.json # https://unix.stackexchange.com/a/343558
 # Make sure the container has access to the config file
 chmod 777 /root/config.json
 
+# If a container named watchtower does not exist, create and configure it.
+# Watchtower is configured to check for updates every hour, and to delete outdated images.
 # https://stackoverflow.com/a/50667460
 if [ ! "$(docker ps -a --format {{.Names}} | grep watchtower)" ]; then
     echo "Please wait while the automatic updater is prepared..."
@@ -27,6 +37,12 @@ else
     docker start watchtower
 fi
 
+# If a container named warrior does not exist, create and configure it.
+# Previous versions of startup.sh did not name containers.
+# Additionally, the /root/config.json file is mounted inside the Docker container at
+# /home/warrior/projects/config.json, allowing user configuration to be persisted across
+# container deletions and Watchtower updates.
+# https://stackoverflow.com/a/50667460
 if [ ! "$(docker ps -a --format {{.Names}} | grep warrior)" ]; then
     echo "Please wait while the Warrior is downloaded and started..."
     echo "This may take a few minutes..."

--- a/startup.sh
+++ b/startup.sh
@@ -52,6 +52,8 @@ if [ ! "$(docker ps -a --format {{.Names}} | grep warrior)" ]; then
     # Allow reading network stats by non-root
     # Run the adduser command as root: https://stackoverflow.com/a/35485346
     docker exec -u 0 -it warrior adduser warrior dip
+    # Restart the container to apply the access changes
+    docker restart warrior
 else
     docker start warrior
 fi

--- a/startup.sh
+++ b/startup.sh
@@ -8,7 +8,7 @@ if [ -f /root/docker_container_id.txt ]; then
     docker cp $CONTAINER_ID:/home/warrior/projects/config.json /root/config.json
     echo "Cleaning up the old version..."
     docker rm $CONTAINER_ID
-    docker system prune -a -f --volumes
+    docker system prune -a -f
     rm /root/docker_container_id.txt
     echo "Now ready to install the new Warrior and automatic updater!"
 fi

--- a/startup.sh
+++ b/startup.sh
@@ -89,16 +89,16 @@ if docker exec -it warrior test -f /tmp/warrior_reboot_required; then
     echo "Detected warrior needing reboot. Rebooting!"
     reboot
 elif docker exec -it warrior test -f /tmp/warrior_poweroff_required; then
-    sleep 5 # Prevent a Watchtower update from shutting down the system
-    if docker exec -it warrior test -f /tmp/warrior_poweroff_required; then
-        echo "Detected warrior needing poweroff. Powering off!"
-        poweroff
-    fi
+    echo "Detected warrior needing poweroff. Powering off!"
+    poweroff
 elif docker ps -f name=warrior -f status=dead | grep warrior; then
     echo "Docker container instance dead. Rebooting!"
     reboot
 elif docker ps -f name=warrior -f status=exited | grep warrior; then
-    echo "Docker container instance exited, Powering off!"
-    poweroff
+    sleep 5 # Prevent a Watchtower update from shutting down the system
+    if docker ps -f name=warrior -f status=exited | grep warrior; then
+        echo "Docker container instance exited, Powering off!"
+        poweroff
+    fi
 fi
 done

--- a/startup.sh
+++ b/startup.sh
@@ -27,7 +27,7 @@ fi
 if [ ! "$(docker ps -a --format {{.Names}} | grep warrior)" ]; then
     echo "Please wait while the Warrior is downloaded and started..."
     echo "This may take a few minutes..."
-    docker run -d -p 8001:8001 --name warrior -v /root/config.json:/home/warrior/projects/config.json atdr.meo.ws/archiveteam/warrior-dockerfile
+    docker run -d -p 8001:8001 --name warrior --mount type=bind,source=/root/config.json,target=/home/warrior/projects/config.json atdr.meo.ws/archiveteam/warrior-dockerfile
     # Allow reading network stats by non-root
     docker exec -it warrior adduser warrior dip
 else

--- a/startup.sh
+++ b/startup.sh
@@ -16,10 +16,13 @@ fi
 # Create a blank configuration file if none exists, otherwise do nothing
 touch /root/config.json # https://unix.stackexchange.com/a/343558
 
+# Make sure the container has access to the config file
+chmod 777 /root/config.json
+
 # https://stackoverflow.com/a/50667460
 if [ ! "$(docker ps -a --format {{.Names}} | grep watchtower)" ]; then
     echo "Please wait while the automatic updater is prepared..."
-    docker run -d --name watchtower -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower
+    docker run -d --name watchtower -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --cleanup --interval 3600
 else
     docker start watchtower
 fi
@@ -29,7 +32,7 @@ if [ ! "$(docker ps -a --format {{.Names}} | grep warrior)" ]; then
     echo "This may take a few minutes..."
     # Mount the user configuration from the host container
     # https://stackoverflow.com/a/54787364, https://docs.docker.com/storage/bind-mounts
-    docker run -d -p 8001:8001 --name warrior -v /root/config.json:/home/warrior/projects/config.json:z atdr.meo.ws/archiveteam/warrior-dockerfile
+    docker run -d -p 8001:8001 --name warrior -v /root/config.json:/home/warrior/projects/config.json atdr.meo.ws/archiveteam/warrior-dockerfile
     # Allow reading network stats by non-root
     docker exec -it warrior adduser warrior dip
 else

--- a/startup.sh
+++ b/startup.sh
@@ -50,7 +50,8 @@ if [ ! "$(docker ps -a --format {{.Names}} | grep warrior)" ]; then
     # https://stackoverflow.com/a/54787364, https://docs.docker.com/storage/bind-mounts
     docker run -d -p 8001:8001 --name warrior -v /root/config.json:/home/warrior/projects/config.json atdr.meo.ws/archiveteam/warrior-dockerfile
     # Allow reading network stats by non-root
-    docker exec -it warrior adduser warrior dip
+    # Run the adduser command as root: https://stackoverflow.com/a/35485346
+    docker exec -u 0 -it warrior adduser warrior dip
 else
     docker start warrior
 fi

--- a/startup.sh
+++ b/startup.sh
@@ -2,18 +2,39 @@
 reset
 echo "=== Starting Warrior Download ==="
 if [ -f /root/docker_container_id.txt ]; then
+    echo "A new, upgraded Warrior capable of running more projects is available and will now be installed..."
     CONTAINER_ID=`cat /root/docker_container_id.txt`
-    docker start $CONTAINER_ID
-else
-    docker run -d -p 8001:8001 --cidfile="/root/docker_container_id.txt" \
-        archiveteam/warrior-dockerfile
-    CONTAINER_ID=`cat /root/docker_container_id.txt`
-
-    # Allow reading network stats by non-root
-    docker exec -it $CONTAINER_ID adduser warrior dip
+    echo "Backing up the user configuration..."
+    docker cp $CONTAINER_ID:/home/warrior/projects/config.json /root/config.json
+    echo "Cleaning up the old version..."
+    docker rm $CONTAINER_ID
+    docker system prune -a -f --volumes
+    rm /root/docker_container_id.txt
+    echo "Now ready to install the new Warrior and automatic updater!"
 fi
 
-if [ ! "$(docker ps | grep archiveteam/warrior-dockerfile)" ]; then
+# Create a blank configuration file if none exists, otherwise do nothing
+touch /root/config.json # https://unix.stackexchange.com/a/343558
+
+# https://stackoverflow.com/a/50667460
+if [ ! "$(docker ps -a --format {{.Names}} | grep watchtower)" ]; then
+    echo "Please wait while the automatic updater is prepared..."
+    docker run -d --name watchtower -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower
+else
+    docker start watchtower
+fi
+
+if [ ! "$(docker ps -a --format {{.Names}} | grep warrior)" ]; then
+    echo "Please wait while the Warrior is downloaded and started..."
+    echo "This may take a few minutes..."
+    docker run -d -p 8001:8001 --name warrior -v /root/config.json:/home/warrior/projects/config.json atdr.meo.ws/archiveteam/warrior-dockerfile
+    # Allow reading network stats by non-root
+    docker exec -it warrior adduser warrior dip
+else
+    docker start warrior
+fi
+
+if [ ! "$(docker ps -a --format {{.Names}} | grep warrior)" ]; then
 echo "***** Startup Failure! ******"
 echo "Unable to start the Docker Instance"
 echo "Sleeping 30 seconds before retrying..."
@@ -21,9 +42,7 @@ sleep 30
 exit 1
 fi
 
-CONTAINER_ID=`cat /root/docker_container_id.txt`
-
-docker exec -it $CONTAINER_ID rm -f /tmp/warrior_reboot_required \
+docker exec -it warrior rm -f /tmp/warrior_reboot_required \
     /tmp/warrior_poweroff_required
 
 echo "Warrior is updating Seesaw Kit."
@@ -32,7 +51,7 @@ echo "Please wait..."
 
 for i in `seq 60`; do
 sleep 5
-if docker top $CONTAINER_ID | grep run-warrior; then
+if docker top warrior | grep run-warrior; then
     break
 elif [ $i -eq 60 ]; then
     echo "***** Startup Failure! ******"
@@ -61,16 +80,16 @@ sleep 20
 
 while true; do
 sleep 10
-if docker exec -it $CONTAINER_ID test -f /tmp/warrior_reboot_required; then
+if docker exec -it warrior test -f /tmp/warrior_reboot_required; then
     echo "Detected warrior needing reboot. Rebooting!"
     reboot
-elif docker exec -it $CONTAINER_ID test -f /tmp/warrior_poweroff_required; then
+elif docker exec -it warrior test -f /tmp/warrior_poweroff_required; then
     echo "Detected warrior needing poweroff. Powering off!"
     poweroff
-elif docker ps -f id=$CONTAINER_ID -f status=dead | grep $CONTAINER_ID; then
+elif docker ps -f name=warrior -f status=dead | grep warrior; then
     echo "Docker container instance dead. Rebooting!"
     reboot
-elif docker ps -f id=$CONTAINER_ID -f status=exited | grep $CONTAINER_ID; then
+elif docker ps -f name=warrior -f status=exited | grep warrior; then
     echo "Docker container instance exited, Powering off!"
     poweroff
 fi


### PR DESCRIPTION
This change detects the old Warrior image (from Docker Hub) by checking for the existence of the `/root/docker_container_id.txt` file. If it detects the old image, it backs up the user `config.json`, deletes the container, prunes everything from Docker, and then deletes the `/root/docker_container_id.txt` file. If the new image or the Watchtower image aren't found, they are installed and configured. Watchtower is configured to run every hour, and to clean up old images. The user configuration is now stored on the host VM and bind mounted into the Docker image so it will survive container updates as well as the complete deletion of the container. Additionally, container names are used instead of container IDs when referring to containers since Watchtower doesn't preserve container IDs after automatic updates. This change also fixes the network statistics indicator.

I have tested this change on versions 3.0 and 3.1 of the Warrior VM image. In particular, I have tested the migration of the user configuration, the persistence of the user configuration, the pruning of old Docker data, and the creation of new containers. I have also tested the creation of new containers when none exist. Watchtower automatic updates should work but hasn’t received a lot of testing.

Some remaining considerations:
- Shutting down the VM when the `warrior` container is stopped will take a few seconds longer because the `startup.sh` now checks a second time that the container is stopped before shutting down the system. This change was made because Watchtower briefly stops containers before updating them, and I didn't want a `warrior` container stopped for updates to cause the VM to shut down. Related, the change appears to cause some Docker-related errors to be briefly printed on screen before shut down.
- During setup of the Docker container, after running the command needed to enable non-root users to access network stats, the container is restarted. The container is given the default grace period of 10 seconds before the restart is forced. I don't believe restarting the container shortly after its first startup causes problems, but I still thought I would mention it.
- Since this change applies to the `startup.sh` script, the Warrior VMs would need to be rebooted to receive this update. I'm not aware of any regular restart interval for the VM, so users would need to be instructed to restart their VMs, and a restart-VM pseudo-project could briefly be made the default project. This project would need to check if it is running in the current Docker image (perhaps by looking for `startup.py`), and if it is not, it would need to create the `/tmp/warrior_reboot_required` file. This reboot project would not affect anyone running the old Warrior Docker image without a VM, and among those running the VM, it would only apply the update for users who have their Warrior set to run the default project. (Currently, [statistics indicate](https://warriorhq.archiveteam.org/stats.json) that there are about 34 Warrior instances running the default project out of a total of about 48 instances overall, though some of them are likely running the old Docker image without a VM, or are already running the new Docker image.) Additionally, it may make sense to release a new Warrior VM image with these updates already applied.
- It seems that many projects still fail inside the new container stating `No usable Wget+At found`. I do not believe this error is related to my changes.