### PR TITLE
Reduce boot delay

### DIFF
--- a/stage.sh
+++ b/stage.sh
@@ -77,4 +77,7 @@ apk add docker
 rc-update add docker boot
 echo "cgroup  /sys/fs/cgroup  cgroup  defaults  0   0" >> /etc/fstab
 
+# Reduce boot delay
+sed -i '/TIMEOUT /c TIMEOUT 1' /boot/extlinux.conf # https://stackoverflow.com/a/43305210
+
 echo "Script Completed, poweroff the virtual machine and package for upload!"

--- a/stage.sh
+++ b/stage.sh
@@ -77,7 +77,12 @@ apk add docker
 rc-update add docker boot
 echo "cgroup  /sys/fs/cgroup  cgroup  defaults  0   0" >> /etc/fstab
 
-# Reduce boot delay
+# Reduce boot delay in boot configuration update script to 1 second (minimum)
+# In case update-extlinux is run and regenerates the boot configuration file
+sed -i '/timeout=/c timeout=1' /etc/update-extlinux.conf
+update-extlinux
+
+# Reduce boot delay to 0.1 seconds (minimum)
 sed -i '/TIMEOUT /c TIMEOUT 1' /boot/extlinux.conf # https://stackoverflow.com/a/43305210
 
 echo "Script Completed, poweroff the virtual machine and package for upload!"


### PR DESCRIPTION
This change reduces the boot delay from 3 seconds to 0.1 seconds (the minimum), as users are unlikely to need to access the boot menu. This change directly writes to `/boot/extlinux.conf` as well as `/etc/update-extlinux.conf` because the boot configuration updater (`update-extlinux`) only seems to accept timeout intervals of 1 second. It also updates the `/etc/update-extlinux.conf` file to specify the minimum timeout of 1 second and runs `update-extlinux` before manually updating the boot configuration file with its minimum timeout of 0.1 seconds. I don't think the boot configuration update script will have any reason to run, so the configuration shouldn't be overwritten. (Boot configuration information: https://wiki.alpinelinux.org/wiki/Bootloaders#Installing_Syslinux).

I tested this change inside an existing image, not as part of `stage.sh` but it should work there.