### PR TITLE
Reduce VirtualBox startup time

### DIFF
--- a/pack-vm.sh
+++ b/pack-vm.sh
@@ -5,6 +5,10 @@ OVA_OUT="archiveteam-warrior-v3.2-beta-$( date +%Y%m%d ).ova"
 
 VBoxManage modifyhd --compact archiveteam-warrior-3-sys.vdi
 
+VBoxManage modifyvm $VMNAME --bioslogodisplaytime 0 --bioslogofadein off --bioslogofadeout off --boot1 disk --boot2 none --boot3 none --boot4 none --biosbootmenu disabled
+
+VBoxManage storagectl $VMNAME --name "IDE Controller" --remove
+
 VBoxManage export $VMNAME \
   --output $OVA_OUT \
   --vsys 0 \


### PR DESCRIPTION
This change reduces the VirtualBox startup time by removing unnecessary devices from the boot order, removing a CD drive, and skipping the VirtualBox BIOS logo and boot menu.