### PR TITLE
Alpine Linux 3.13.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please note that from versions 3.2 and newer, the OVA file will be smaller. When
 ## Building a warrior
 
 1. Install VirtualBox.
-2. Download the ISO file for Alpine Linux `alpine-virt-3.12.0-x86_64.iso`
+2. Download the ISO file for Alpine Linux `alpine-virt-3.13.2-x86_64.iso`
 3. Run `./build-vm.sh` to create an empty Virtual Machine.
 4. Boot up the virtual machine and wait for Alpine's login prompt to appear.
 5. Follow the instructions for installing to disk: https://wiki.alpinelinux.org/wiki/Install_to_disk using the options mentioned in `stage.sh`.

--- a/build-vm.sh
+++ b/build-vm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 VMNAME="archiveteam-warrior-3.2-beta"
-INSTALL_ISO="alpine-virt-3.12.0-x86_64.iso"
+INSTALL_ISO="alpine-virt-3.13.2-x86_64.iso"
 
 VBoxManage createvm --name $VMNAME --ostype Linux_64 --register
 VBoxManage modifyvm $VMNAME \

--- a/build-vm.sh
+++ b/build-vm.sh
@@ -6,7 +6,7 @@ INSTALL_ISO="alpine-virt-3.13.2-x86_64.iso"
 VBoxManage createvm --name $VMNAME --ostype Linux_64 --register
 VBoxManage modifyvm $VMNAME \
   --memory 400 \
-  --vram 1 \
+  --vram 12 \
   --acpi on \
   --ioapic on \
   --cpus 1 \

--- a/stage.sh
+++ b/stage.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #This script is to setup a default install of Alpine Linux installed to disk.
 # The Following Settings where used in the install
-# ISO: alpine-virt-3.12.0-x86_64.iso
+# ISO: alpine-virt-3.13.2-x86_64.iso
 # Disk: Blank
 # Keyboard: us | Variant: us
 # Hostname: warrior
@@ -64,7 +64,7 @@ For details, see the ArchiveTeam wiki and Docker documentation.
 END
 
 # add community sources
-echo "http://dl-3.alpinelinux.org/alpine/v3.12/community" >> /etc/apk/repositories
+echo "http://dl-3.alpinelinux.org/alpine/v3.13/community" >> /etc/apk/repositories
 set > /root/env.sh
 
 #download boot script


### PR DESCRIPTION
This PR makes the changes needed to upgrade Alpine Linux from version 3.12.0 to version 3.13.2. Note: this change is untested.