### PR TITLE
Fix compatibility with recent Warrior image update

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -9,23 +9,30 @@ if grep -q "v3.19" "/etc/apk/repositories"; then
     :
 # Warrior 3.2, upgrade possible
 # Update Alpine Linux from 3.13.2 to 3.19
-elif grep -q "v3.13" "/etc/apk/repositories"; then
-    echo "=== Updating Alpine and Docker ==="
-    echo "Alpine and Docker need to be updated in order to remain compatible with the latest Warrior updates"
-    # Signing keys were rotated, update them
-    apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/v3.13/main -u alpine-keys
-    echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/main/" >| /etc/apk/repositories
-    echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/community/" >> /etc/apk/repositories
-    # Note: this updates to the latest Docker/package version available for Alpine Linux 3.19 at the time the upgrade occurs.
-    # This may ultimately result in different users having slightly different versions of Docker/system packages installed,
-    # but this will stabilize once Alpine 3.19 exits support.
-    # Additional note: the terminal will still display "Welcome to Alpine Linux 3.13" at the login prompt
-    apk update
-    apk add --upgrade apk-tools
-    apk upgrade --available
-    # https://wiki.alpinelinux.org/wiki/Upgrading_Alpine#Upgrading_an_Alpine_Linux_Hard-disk_installation
-    sync
-    echo "Alpine/Docker updates complete, now rebooting"
+elif grep -q "v3.13" "/etc/apk/repositories"; || [ -f alpine_updating.txt ] then
+    if
+        touch "alpine_updating.txt" &&
+        echo "=== Updating Alpine and Docker ===" &&
+        echo "Alpine and Docker need to be updated in order to remain compatible with the latest Warrior updates" &&
+        # Signing keys were rotated, update them
+        apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/v3.13/main -u alpine-keys &&
+        echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/main/" >| /etc/apk/repositories &&
+        echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/community/" >> /etc/apk/repositories &&
+        # Note: this updates to the latest Docker/package version available for Alpine Linux 3.19 at the time the upgrade occurs.
+        # This may ultimately result in different users having slightly different versions of Docker/system packages installed,
+        # but this will stabilize once Alpine 3.19 exits support.
+        # Additional note: the terminal will still display "Welcome to Alpine Linux 3.13" at the login prompt
+        apk update &&
+        apk add --upgrade apk-tools &&
+        apk upgrade --available &&
+        # https://wiki.alpinelinux.org/wiki/Upgrading_Alpine#Upgrading_an_Alpine_Linux_Hard-disk_installation
+        sync
+    then
+        rm alpine_updating.txt
+        echo "Alpine/Docker updates complete, now rebooting"
+    else
+        echo "Alpine update failed, rebooting"
+    fi
     reboot
     sleep 5
 # EOL message for version 3.0, 3.1, and 3.2-beta

--- a/startup.sh
+++ b/startup.sh
@@ -5,11 +5,11 @@ reset
 
 # no upgrade needed
 # https://stackoverflow.com/a/11287896
-if grep -q "v3.19" "/etc/apk/repositories" && ! grep -q "updating" /root/alpine_updating.txt; then
+if grep -q "v3.19" "/etc/apk/repositories" && ! grep -s -q "updating" /root/alpine_updating.txt; then
     :
 # Warrior 3.2, upgrade possible
 # Update Alpine Linux from 3.13.2 to 3.19
-elif grep -q "updating" /root/alpine_updating.txt || grep -q "v3.13" "/etc/apk/repositories"; then
+elif grep -s -q "updating" /root/alpine_updating.txt || grep -q "v3.13" "/etc/apk/repositories"; then
     if
         echo "updating" >| /root/alpine_updating.txt &&
         echo "=== Updating Alpine and Docker ===" &&

--- a/startup.sh
+++ b/startup.sh
@@ -17,15 +17,15 @@ else
     echo "Alpine and Docker need to be updated in order to remain compatible with the latest Warrior updates"
     # Signing keys were rotated, update them
     apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/v3.12/main -u alpine-keys
-    apk update
-    apk add --upgrade --no-cache -X https://dl-cdn.alpinelinux.org/alpine/v3.19/main -u apk-tools
+    # apk update
+    # apk add --upgrade --no-cache -X https://dl-cdn.alpinelinux.org/alpine/v3.19/main -u apk-tools
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/main/" >| /etc/apk/repositories
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/community/" >> /etc/apk/repositories
     # Note: this updates to the latest Docker/package version availables for Alpine 3.19 at the time the upgrade occurs.
     # This may ultimately result in different users having slightly different versions of Docker/system packages installed,
     # but this will stabilize once Alpine 3.19 exits support.
     apk update
-    # apk add --upgrade apk-tools
+    apk add --upgrade apk-tools
     apk upgrade --available
     # https://wiki.alpinelinux.org/wiki/Upgrading_Alpine
     sync

--- a/startup.sh
+++ b/startup.sh
@@ -15,6 +15,9 @@ if [ "${SERVER_VERSION_MAJOR}" -ge 24 ] && \
 else
     echo "=== Updating Alpine and Docker ==="
     echo "Alpine and Docker need to be updated in order to remain compatible with the latest Warrior updates"
+    # Update apk-tools to fix segfault
+    apk update
+    apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/v3.12/main -u apk-tools
     # Signing keys were rotated, update them
     apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/v3.12/main -u alpine-keys
     # apk update

--- a/startup.sh
+++ b/startup.sh
@@ -42,6 +42,8 @@ else
    echo ""
    echo "Apologies for the inconvenience, and thank you for contributing to Archive Team projects!"
    sleep 604800 # sleep for 1 week
+   reboot
+   sleep 5
    exit
 fi
 

--- a/startup.sh
+++ b/startup.sh
@@ -9,7 +9,7 @@ if grep -q "v3.19" "/etc/apk/repositories"; then
     :
 # Warrior 3.2, upgrade possible
 # Update Alpine Linux from 3.13.2 to 3.19
-elif grep -q "updating" "/root/alpine_updating.txt"; || grep -q "v3.13" "/etc/apk/repositories"; then
+elif grep -q "updating" "/root/alpine_updating.txt" || grep -q "v3.13" "/etc/apk/repositories"; then
     if
         echo "updating" >| /root/alpine_updating.txt &&
         echo "=== Updating Alpine and Docker ===" &&

--- a/startup.sh
+++ b/startup.sh
@@ -29,6 +29,7 @@ else
     sync
     echo "Alpine/Docker updates complete, now rebooting"
     reboot
+    sleep 5
 fi
 
 echo "=== Starting Warrior Download ==="

--- a/startup.sh
+++ b/startup.sh
@@ -5,11 +5,11 @@ reset
 
 # no upgrade needed
 # https://stackoverflow.com/a/11287896
-if grep -q "v3.19" "/etc/apk/repositories" && [ ! -f "alpine_updating.txt" ]; then
+if grep -q "v3.19" "/etc/apk/repositories" && ! grep -q "updating" /root/alpine_updating.txt; then
     :
 # Warrior 3.2, upgrade possible
 # Update Alpine Linux from 3.13.2 to 3.19
-elif [ -f "alpine_updating.txt" ] || grep -q "v3.13" "/etc/apk/repositories"; then
+elif grep -q "updating" /root/alpine_updating.txt || grep -q "v3.13" "/etc/apk/repositories"; then
     if
         echo "updating" >| /root/alpine_updating.txt &&
         echo "=== Updating Alpine and Docker ===" &&

--- a/startup.sh
+++ b/startup.sh
@@ -5,7 +5,7 @@ reset
 
 # no upgrade needed
 # https://stackoverflow.com/a/11287896
-if grep -q "v3.19" "/etc/apk/repositories"; then
+if grep -q "v3.19" "/etc/apk/repositories" && [ ! -f "alpine_updating.txt" ]; then
     :
 # Warrior 3.2, upgrade possible
 # Update Alpine Linux from 3.13.2 to 3.19

--- a/startup.sh
+++ b/startup.sh
@@ -9,7 +9,7 @@ if grep -q "v3.19" "/etc/apk/repositories"; then
     :
 # Warrior 3.2, upgrade possible
 # Update Alpine Linux from 3.13.2 to 3.19
-elif grep -q "v3.13" "/etc/apk/repositories"; || [ -f alpine_updating.txt ] then
+elif [ -f alpine_updating.txt ] || grep -q "v3.13" "/etc/apk/repositories"; then
     if
         touch "alpine_updating.txt" &&
         echo "=== Updating Alpine and Docker ===" &&

--- a/startup.sh
+++ b/startup.sh
@@ -33,12 +33,15 @@ elif grep -q "v3.13" "/etc/apk/repositories"; then
 # However, 3.1 and 3.2-beta freeze on boot after the upgrade
 else
    echo "=== ACTION REQUIRED: PLEASE UPGRADE YOUR VIRTUAL MACHINE ==="
-   echo "Your version of the Archive Team Warrior (version 3.0 (2017), 3.1 (2020), or 3.2-beta (2021)) is no longer 
-   compatible with the latest Warrior updates."
-   echo "Please delete this VM and replace it with Warrior 3.2, Warrior 4, or later, available at 
-   https://warriorhq.archiveteam.org/downloads/."
+   echo ""
+   echo "Your version of the Archive Team Warrior (version 3.0 (2017), 3.1 (2020), or 3.2-beta (2021)) is no longer compatible with the latest Warrior updates."
+   echo ""
+   echo "Please delete this VM and replace it with Warrior 3.2, Warrior 4, or later, available at https://warriorhq.archiveteam.org/downloads/."
+   echo ""
    echo "If you have any questions please visit our wiki: https://wiki.archiveteam.org/index.php/ArchiveTeam_Warrior or join us on IRC: #warrior on irc.hackint.org."
+   echo ""
    echo "Apologies for the inconvenience, and thank you for contributing to Archive Team projects!"
+   sleep 604800 # sleep for 1 week
    exit
 fi
 

--- a/startup.sh
+++ b/startup.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
 reset
 
-# Detect if Alpine/Docker upgrade is required
+# Detect if Alpine Linux/Docker upgrade is required
 
 # no upgrade needed
 # https://stackoverflow.com/a/11287896
 if grep -q "v3.19" "/etc/apk/repositories"; then
     :
 # Warrior 3.2, upgrade possible
-# Update Alpine from 3.13.2 to 3.19
+# Update Alpine Linux from 3.13.2 to 3.19
 elif grep -q "v3.13" "/etc/apk/repositories"; then
     echo "=== Updating Alpine and Docker ==="
     echo "Alpine and Docker need to be updated in order to remain compatible with the latest Warrior updates"
@@ -16,7 +16,7 @@ elif grep -q "v3.13" "/etc/apk/repositories"; then
     apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/v3.13/main -u alpine-keys
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/main/" >| /etc/apk/repositories
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/community/" >> /etc/apk/repositories
-    # Note: this updates to the latest Docker/package version availables for Alpine 3.19 at the time the upgrade occurs.
+    # Note: this updates to the latest Docker/package version available for Alpine Linux 3.19 at the time the upgrade occurs.
     # This may ultimately result in different users having slightly different versions of Docker/system packages installed,
     # but this will stabilize once Alpine 3.19 exits support.
     # Additional note: the terminal will still display "Welcome to Alpine Linux 3.13" at the login prompt
@@ -30,7 +30,7 @@ elif grep -q "v3.13" "/etc/apk/repositories"; then
     sleep 5
 # EOL message for version 3.0, 3.1, and 3.2-beta
 # Warrior 3.0 segfaults during upgrade attempt
-# Warrior 3.1 and Warrior 3.2-beta also segfault during upgrade but that can be fixed by upgrading apk-tools to the latest version for Alpine 3.12 beforehand
+# Warrior 3.1 and Warrior 3.2-beta also segfault during upgrade but that can be fixed by upgrading apk-tools to the latest version for Alpine Linux 3.12 beforehand
 # However, 3.1 and 3.2-beta still freeze on boot after the upgrade
 else
    echo "=== ACTION REQUIRED: PLEASE UPGRADE YOUR VIRTUAL MACHINE ==="

--- a/startup.sh
+++ b/startup.sh
@@ -16,7 +16,7 @@ else
     echo "=== Updating Alpine and Docker ==="
     echo "Alpine and Docker need to be updated in order to remain compatible with the latest Warrior updates"
     # Signing keys were rotated, update them
-    apk add -X https://dl-cdn.alpinelinux.org/alpine/v3.13/main -u alpine-keys
+    apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/v3.12/main -u alpine-keys
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/main/" >| /etc/apk/repositories
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/community/" >> /etc/apk/repositories
     # Note: this updates to the latest Docker/package version availables for Alpine 3.19 at the time the upgrade occurs.

--- a/startup.sh
+++ b/startup.sh
@@ -9,7 +9,7 @@ if grep -q "v3.19" "/etc/apk/repositories"; then
     :
 # Warrior 3.2, upgrade possible
 # Update Alpine Linux from 3.13.2 to 3.19
-elif [grep -q "v3.13" "/etc/apk/repositories"] || [ -f alpine_updating.txt ] then
+elif grep -q "v3.13" "/etc/apk/repositories"; || [ -f alpine_updating.txt ] then
     if
         touch "alpine_updating.txt" &&
         echo "=== Updating Alpine and Docker ===" &&

--- a/startup.sh
+++ b/startup.sh
@@ -42,7 +42,7 @@ elif grep -s -q "updating" /root/alpine_updating.txt || grep -q "v3.13" "/etc/ap
 else
    echo "=== ACTION REQUIRED: PLEASE UPGRADE YOUR VIRTUAL MACHINE ==="
    echo ""
-   echo "Your version of the Archive Team Warrior (version 3.0 (2017), 3.1 (2020), or 3.2-beta (2021)) is no longer compatible with the latest Warrior updates."
+   echo "Your version of the Archive Team Warrior (version 3.0 (2017), 3.1 (2020), or 3.2-beta (2021)) is no longer compatible with the latest Warrior updates as of December 2023."
    echo ""
    echo "Please delete this VM and replace it with Warrior 3.2, Warrior 4, or later, available at https://warriorhq.archiveteam.org/downloads/."
    echo ""

--- a/startup.sh
+++ b/startup.sh
@@ -9,7 +9,7 @@ if grep -q "v3.19" "/etc/apk/repositories"; then
     :
 # Warrior 3.2, upgrade possible
 # Update Alpine Linux from 3.13.2 to 3.19
-elif [ -f /root/alpine_updating.txt ] || grep -q "v3.13" "/etc/apk/repositories"; then
+elif grep -q "updating" "/root/alpine_updating.txt"; || grep -q "v3.13" "/etc/apk/repositories"; then
     if
         echo "updating" >| /root/alpine_updating.txt &&
         echo "=== Updating Alpine and Docker ===" &&

--- a/startup.sh
+++ b/startup.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 reset
 
-# Upgrade Alpine/Docker if necessary
+# Detect if Alpine/Docker upgrade is required
 
 # no upgrade needed
+# https://stackoverflow.com/a/11287896
 if grep -q "v3.19" "/etc/apk/repositories"; then
     :
 # Warrior 3.2, upgrade possible
@@ -13,24 +14,24 @@ elif grep -q "v3.13" "/etc/apk/repositories"; then
     echo "Alpine and Docker need to be updated in order to remain compatible with the latest Warrior updates"
     # Signing keys were rotated, update them
     apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/v3.13/main -u alpine-keys
-    # apk update
-    # apk add --upgrade --no-cache -X https://dl-cdn.alpinelinux.org/alpine/v3.19/main -u apk-tools
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/main/" >| /etc/apk/repositories
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/community/" >> /etc/apk/repositories
     # Note: this updates to the latest Docker/package version availables for Alpine 3.19 at the time the upgrade occurs.
     # This may ultimately result in different users having slightly different versions of Docker/system packages installed,
     # but this will stabilize once Alpine 3.19 exits support.
+    # Additional note: the terminal will still display "Welcome to Alpine Linux 3.13" at the login prompt
     apk update
     apk add --upgrade apk-tools
     apk upgrade --available
-    # https://wiki.alpinelinux.org/wiki/Upgrading_Alpine
+    # https://wiki.alpinelinux.org/wiki/Upgrading_Alpine#Upgrading_an_Alpine_Linux_Hard-disk_installation
     sync
     echo "Alpine/Docker updates complete, now rebooting"
     reboot
     sleep 5
+# EOL message for version 3.0, 3.1, and 3.2-beta
 # Warrior 3.0 segfaults during upgrade attempt
 # Warrior 3.1 and Warrior 3.2-beta also segfault during upgrade but that can be fixed by upgrading apk-tools to the latest version for Alpine 3.12 beforehand
-# However, 3.1 and 3.2-beta freeze on boot after the upgrade
+# However, 3.1 and 3.2-beta still freeze on boot after the upgrade
 else
    echo "=== ACTION REQUIRED: PLEASE UPGRADE YOUR VIRTUAL MACHINE ==="
    echo ""

--- a/startup.sh
+++ b/startup.sh
@@ -17,13 +17,15 @@ else
     echo "Alpine and Docker need to be updated in order to remain compatible with the latest Warrior updates"
     # Signing keys were rotated, update them
     apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/v3.12/main -u alpine-keys
+    apk update
+    apk add --upgrade --no-cache -X https://dl-cdn.alpinelinux.org/alpine/v3.19/main -u apk-tools
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/main/" >| /etc/apk/repositories
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/community/" >> /etc/apk/repositories
     # Note: this updates to the latest Docker/package version availables for Alpine 3.19 at the time the upgrade occurs.
     # This may ultimately result in different users having slightly different versions of Docker/system packages installed,
     # but this will stabilize once Alpine 3.19 exits support.
     apk update
-    apk add --upgrade apk-tools
+    # apk add --upgrade apk-tools
     apk upgrade --available
     # https://wiki.alpinelinux.org/wiki/Upgrading_Alpine
     sync

--- a/startup.sh
+++ b/startup.sh
@@ -9,9 +9,9 @@ if grep -q "v3.19" "/etc/apk/repositories"; then
     :
 # Warrior 3.2, upgrade possible
 # Update Alpine Linux from 3.13.2 to 3.19
-elif [ -f alpine_updating.txt ] || grep -q "v3.13" "/etc/apk/repositories"; then
+elif [ -f /root/alpine_updating.txt ] || grep -q "v3.13" "/etc/apk/repositories"; then
     if
-        touch "alpine_updating.txt" &&
+        touch /root/alpine_updating.txt &&
         echo "=== Updating Alpine and Docker ===" &&
         echo "Alpine and Docker need to be updated in order to remain compatible with the latest Warrior updates" &&
         # Signing keys were rotated, update them
@@ -28,7 +28,7 @@ elif [ -f alpine_updating.txt ] || grep -q "v3.13" "/etc/apk/repositories"; then
         # https://wiki.alpinelinux.org/wiki/Upgrading_Alpine#Upgrading_an_Alpine_Linux_Hard-disk_installation
         sync
     then
-        rm alpine_updating.txt
+        rm /root/alpine_updating.txt
         echo "Alpine/Docker updates complete, now rebooting"
     else
         echo "Alpine update failed, rebooting"

--- a/startup.sh
+++ b/startup.sh
@@ -2,24 +2,17 @@
 reset
 
 # Upgrade Alpine/Docker if necessary
-# https://stackoverflow.com/a/59287182
-SERVER_VERSION=$(docker version -f "{{.Server.Version}}")
-SERVER_VERSION_MAJOR=$(echo "$SERVER_VERSION"| cut -d'.' -f 1)
-SERVER_VERSION_MINOR=$(echo "$SERVER_VERSION"| cut -d'.' -f 2)
-SERVER_VERSION_BUILD=$(echo "$SERVER_VERSION"| cut -d'.' -f 3)
 
-if [ "${SERVER_VERSION_MAJOR}" -ge 24 ] && \
-   [ "${SERVER_VERSION_MINOR}" -ge 0 ]  && \
-   [ "${SERVER_VERSION_BUILD}" -ge 7 ]; then
-    reset
-else
+# no upgrade needed
+if grep -q "v3.19" "/etc/apk/repositories"; then
+    :
+# Warrior 3.2, upgrade possible
+# Update Alpine from 3.13.2 to 3.19
+elif grep -q "v3.13" "/etc/apk/repositories"; then
     echo "=== Updating Alpine and Docker ==="
     echo "Alpine and Docker need to be updated in order to remain compatible with the latest Warrior updates"
-    # Update apk-tools to fix segfault
-    apk update
-    apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/v3.12/main -u apk-tools
     # Signing keys were rotated, update them
-    apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/v3.12/main -u alpine-keys
+    apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/v3.13/main -u alpine-keys
     # apk update
     # apk add --upgrade --no-cache -X https://dl-cdn.alpinelinux.org/alpine/v3.19/main -u apk-tools
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/main/" >| /etc/apk/repositories
@@ -35,6 +28,18 @@ else
     echo "Alpine/Docker updates complete, now rebooting"
     reboot
     sleep 5
+# Warrior 3.0 segfaults during upgrade attempt
+# Warrior 3.1 and Warrior 3.2-beta also segfault during upgrade but that can be fixed by upgrading apk-tools to the latest version for Alpine 3.12 beforehand
+# However, 3.1 and 3.2-beta freeze on boot after the upgrade
+else
+   echo "=== ACTION REQUIRED: PLEASE UPGRADE YOUR VIRTUAL MACHINE ==="
+   echo "Your version of the Archive Team Warrior (version 3.0 (2017), 3.1 (2020), or 3.2-beta (2021)) is no longer 
+   compatible with the latest Warrior updates."
+   echo "Please delete this VM and replace it with Warrior 3.2, Warrior 4, or later, available at 
+   https://warriorhq.archiveteam.org/downloads/."
+   echo "If you have any questions please visit our wiki: https://wiki.archiveteam.org/index.php/ArchiveTeam_Warrior or join us on IRC: #warrior on irc.hackint.org."
+   echo "Apologies for the inconvenience, and thank you for contributing to Archive Team projects!"
+   exit
 fi
 
 echo "=== Starting Warrior Download ==="

--- a/startup.sh
+++ b/startup.sh
@@ -11,7 +11,7 @@ if grep -q "v3.19" "/etc/apk/repositories"; then
 # Update Alpine Linux from 3.13.2 to 3.19
 elif [ -f /root/alpine_updating.txt ] || grep -q "v3.13" "/etc/apk/repositories"; then
     if
-        touch /root/alpine_updating.txt &&
+        echo "updating" >| /root/alpine_updating.txt &&
         echo "=== Updating Alpine and Docker ===" &&
         echo "Alpine and Docker need to be updated in order to remain compatible with the latest Warrior updates" &&
         # Signing keys were rotated, update them

--- a/startup.sh
+++ b/startup.sh
@@ -15,9 +15,10 @@ if [ "${SERVER_VERSION_MAJOR}" -ge 24 ] && \
 else
     echo "=== Updating Alpine and Docker ==="
     echo "Alpine and Docker need to be updated in order to remain compatible with the latest Warrior updates"
+    # Signing keys were rotated, update them
+    apk add -X https://dl-cdn.alpinelinux.org/alpine/v3.13/main -u alpine-keys
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/main/" >| /etc/apk/repositories
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.19/community/" >> /etc/apk/repositories
-    apk add -X https://dl-cdn.alpinelinux.org/alpine/v3.19/main -u alpine-keys
     # Note: this updates to the latest Docker/package version availables for Alpine 3.19 at the time the upgrade occurs.
     # This may ultimately result in different users having slightly different versions of Docker/system packages installed,
     # but this will stabilize once Alpine 3.19 exits support.

--- a/startup.sh
+++ b/startup.sh
@@ -9,7 +9,7 @@ if grep -q "v3.19" "/etc/apk/repositories"; then
     :
 # Warrior 3.2, upgrade possible
 # Update Alpine Linux from 3.13.2 to 3.19
-elif grep -q "updating" "/root/alpine_updating.txt" || grep -q "v3.13" "/etc/apk/repositories"; then
+elif [ -f "alpine_updating.txt" ] || grep -q "v3.13" "/etc/apk/repositories"; then
     if
         echo "updating" >| /root/alpine_updating.txt &&
         echo "=== Updating Alpine and Docker ===" &&

--- a/startup.sh
+++ b/startup.sh
@@ -9,7 +9,7 @@ if grep -q "v3.19" "/etc/apk/repositories"; then
     :
 # Warrior 3.2, upgrade possible
 # Update Alpine Linux from 3.13.2 to 3.19
-elif grep -q "v3.13" "/etc/apk/repositories"; || [ -f alpine_updating.txt ] then
+elif [grep -q "v3.13" "/etc/apk/repositories"] || [ -f alpine_updating.txt ] then
     if
         touch "alpine_updating.txt" &&
         echo "=== Updating Alpine and Docker ===" &&


### PR DESCRIPTION
The recent upgrade of the Warrior Docker image to Debian Bookworm also requires a Docker update in order to maintain internet connectivity from within the container. This updated version of Docker is not available on any of the currently deployed Alpine Linux versions for Warrior 3.x. This PR automatically updates the Warrior 3.2 VM image from Alpine Linux version 3.13.2 to 3.19.0 in order to install the updated Docker version. This upgrade does not appear to be possible on Warrior 3.0, 3.1, and 3.2-beta, so these versions will instead display an EOL message and reboot weekly. Warrior 4 is unaffected by the issue.

Known/potential issues:
* This updates to the latest Docker/package versions available for Alpine Linux 3.19 at the time the upgrade occurs. As a result, different users may end up running slightly different versions of Docker and other packages. This will stabilize when Alpine Linux 3.19 loses support.
~~* If the upgrade gets interrupted for some reason, it probably wouldn't be automatically attempted again. I don't really see how that could happen, and if people do have that issue it would be fixable by adding more checks to startup.sh.~~ Update interruption checking has been added
* "Welcome to Alpine Linux 3.13" is still displayed at the terminal login prompt. (Edit: however an updated kernel version is displayed after the update. Kernel version `5.10.16-0-virt` before the update, kernel version `6.6.7-0-virt` or later after the update.)

(Warrior 3.0 segfaults during the upgrade attempt. Warrior 3.1 and Warrior 3.2-beta also segfault during upgrade but that can be fixed by upgrading apk-tools to the latest version for Alpine Linux 3.12 beforehand. However, 3.1 and 3.2-beta still freeze on boot after the upgrade.)